### PR TITLE
corrected documentation of success page in the custom plugin 

### DIFF
--- a/confirmation-new.js
+++ b/confirmation-new.js
@@ -7,6 +7,7 @@ window._sdbag = {
         currency: 'EUR',
         language: 'DE',
       },
+      orderId: '342sfvds',
       page_type: 'SUCCESS', // Needs to be in capital letters
       customer: {
         first_name: 'John',
@@ -22,6 +23,7 @@ window._sdbag = {
         tax_number: '12312321', //Mandatory for IT,ES and PT
         phone_number: '+4917484546'
       }
+}
 
 // This indicates which page you are initializing the plugin. Use "success" for success page.
 

--- a/confirmation-new.js
+++ b/confirmation-new.js
@@ -23,7 +23,7 @@ window._sdbag = {
         tax_number: '12312321', //Mandatory for IT,ES and PT
         phone_number: '+4917484546'
       }
-}
+};
 
 // This indicates which page you are initializing the plugin. Use "success" for success page.
 


### PR DESCRIPTION
### Description of the change
- orderId
- closusre

### Reason:
-  there was an object without a closing curly bracket
- without the orderID, products cannot be created because the requirement for identifiers on the create request is not fulfilled